### PR TITLE
use skeleton for loading status

### DIFF
--- a/src/components/JobApplicationList.jsx
+++ b/src/components/JobApplicationList.jsx
@@ -90,7 +90,7 @@ export default function JobApplicationList({ searchTerm }) {
                         {filteredData.map(jobApplication => (
                             <Grid item key={jobApplication.id} xs={12} sm={6} md={4}>
                                 <Card sx={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
-                                    <CardContent>
+                                    <CardContent sx={{ flexGrow: 1 }}>
                                         <Typography sx={{ fontSize: 12 }} color="text.secondary" gutterBottom>
                                             <CalendarMonthRoundedIcon fontSize="inherit"/> {jobApplication.appliedDate}
                                         </Typography>
@@ -108,7 +108,14 @@ export default function JobApplicationList({ searchTerm }) {
                                         </Typography>
                                     </CardContent>
                                     <CardContent sx={{ flexGrow: 1 }}>
-                                        <Typography color="text.secondary">
+                                        <Typography color="text.secondary"
+                                            sx={{
+                                                display: '-webkit-box',
+                                                WebkitBoxOrient: 'vertical',
+                                                overflow: 'hidden',
+                                                WebkitLineClamp: 3
+                                            }}
+                                        >
                                             <CommentRoundedIcon fontSize="inherit"/>
                                             <br/>
                                             {jobApplication.description}
@@ -116,11 +123,11 @@ export default function JobApplicationList({ searchTerm }) {
                                         <Typography color="text.secondary">
                                             <LinkRoundedIcon fontSize="inherit"/> <Link href={jobApplication.jobUrl} underline="hover" color="inherit">job link</Link>
                                         </Typography>
-                                        <CardActions>
-                                            <Button size="small" color="info" variant="outlined" startIcon={<ReadMoreIcon />} onClick={() => handleOpen(jobApplication)}>Edit</Button>
-                                            <Button size="small" color="warning" variant="outlined" startIcon={<DeleteIcon />} onClick={() => handleDeleteJobApplication(jobApplication.id)}>Delete</Button>
-                                        </CardActions>
                                     </CardContent>
+                                    <CardActions sx={{ justifyContent: 'flex-end' }}>
+                                        <Button size="small" color="info" variant="outlined" startIcon={<ReadMoreIcon />} onClick={() => handleOpen(jobApplication)}>Edit</Button>
+                                        <Button size="small" color="warning" variant="outlined" startIcon={<DeleteIcon />} onClick={() => handleDeleteJobApplication(jobApplication.id)}>Delete</Button>
+                                    </CardActions>
                                 </Card>
                             </Grid>
                         ))}

--- a/src/components/Loading.jsx
+++ b/src/components/Loading.jsx
@@ -1,23 +1,24 @@
 import Card from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
-import Container from '@mui/material/Container';
 import Grid from '@mui/material/Grid';
-import CircularProgress from '@mui/material/CircularProgress';
+import CardActions from '@mui/material/CardActions';
+import Skeleton from '@mui/material/Skeleton';
 import { useMediaQuery } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
 
-const LoadingCard = ({ maxHeight = '33vh' }) => (
+const LoadingCard = () => (
     <Card sx={{ height: '100%', display: 'flex', flexDirection: 'column' }} data-testid="loading-card" >
-        <CardContent
-            sx={{
-                display: 'flex',
-                justifyContent: 'center',
-                alignItems: 'center',
-                height: maxHeight
-            }}
-        >
-            <CircularProgress />
+        <CardContent>
+            <Skeleton variant="text" width="35%" />
+            <Skeleton variant="text" width="30%" />
+            <Skeleton variant="text" width="50%" />
+            <Skeleton variant="rectangular" height={118} sx={{ my: 2 }} />
+            <Skeleton variant="text" width="80%" />
         </CardContent>
+        <CardActions sx={{ justifyContent: 'flex-end' }}>
+            <Skeleton variant="rectangular" width={80} height={30} sx={{ mr: 1 }} />
+            <Skeleton variant="rectangular" width={80} height={30} />
+        </CardActions>
     </Card>
 );
 
@@ -46,14 +47,8 @@ export default function Loading() {
     }
 
     return (
-        <div>
-            <main>
-                <Container sx={{ py: 8 }} maxWidth="md">
-                    <Grid container spacing={4}>
-                        {cards}
-                    </Grid>
-                </Container>
-            </main>
-        </div>
+        <Grid container spacing={4}>
+            {cards}
+        </Grid>
     );
 }


### PR DESCRIPTION
- replace CircularProgress with skeleton to enhance UX experience
- limit jobApplication.description to show only 3 lines so it won't change the height of the card too much
- make buttons to display at the bottom right corner


this is for https://github.com/januschung/job-winner-ui/issues/29 and https://github.com/januschung/job-winner-ui/issues/30