### PR TITLE
make search to reset filter status to all

### DIFF
--- a/src/components/JobApplicationList.jsx
+++ b/src/components/JobApplicationList.jsx
@@ -51,11 +51,10 @@ export default function JobApplicationList({ searchTerm }) {
         : new Date(b.appliedDate) - new Date(a.appliedDate);
     });
   };
+  
   useEffect(() => {
-    if (data) {
-      setLocalData(sortJobApplications(data.allJobApplication));
-    }
-  }, [data]);
+    setSelectedStatus('all');
+  }, [searchTerm]);
 
   useEffect(() => {
     if (data?.allJobApplication) {


### PR DESCRIPTION
close https://github.com/januschung/job-winner-ui/issues/94

To keep logic simple, reset filtering to all when search bar is used.

